### PR TITLE
fix: update cleanup failed logic

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -29,7 +29,8 @@
   "tiles_storage_provider": "TILES_STORAGE_PROVIDER",
   "fs": {
     "tiles_location": "FS_TILES_LOCATION",
-    "sources_location": "FS_SOURCES_LOCATION"
+    "sources_location": "FS_SOURCES_LOCATION",
+    "blacklist_sources": "BLACK_LIST_SOURCES"
   },
   "s3": {
     "apiVersion": "S3_API_VERSION",

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -30,7 +30,7 @@
   "fs": {
     "tiles_location": "FS_TILES_LOCATION",
     "sources_location": "FS_SOURCES_LOCATION",
-    "blacklist_sources": "BLACK_LIST_SOURCES"
+    "blacklist_sources_location": "FS_BLACK_LIST_SOURCES_LOCATION"
   },
   "s3": {
     "apiVersion": "S3_API_VERSION",

--- a/config/default.json
+++ b/config/default.json
@@ -24,7 +24,7 @@
   "fs": {
     "tiles_location": "./tiles",
     "sources_location": "/tiffs",
-    "blacklist_sources": "test"
+    "blacklist_sources_location": "test"
   },
   "s3": {
     "apiVersion": "2006-03-01",

--- a/config/default.json
+++ b/config/default.json
@@ -23,7 +23,8 @@
   "tiles_storage_provider": "S3",
   "fs": {
     "tiles_location": "./tiles",
-    "sources_location": "/tiffs"
+    "sources_location": "/tiffs",
+    "blacklist_sources": "test"
   },
   "s3": {
     "apiVersion": "2006-03-01",

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -39,5 +39,5 @@ data:
   CLEANUP_TYPES_FAILED_INGESTION_TASKS: {{ .Values.env.cleanupTypes.failedIngestionTasks | quote }}
   CLEANUP_TYPES_SUCCESSFUL_INGESTION: {{ .Values.env.cleanupTypes.successfulIngestion | quote }}
   CLEANUP_TYPES_FAILED_INCOMING_SYNC_TASKS: {{ .Values.env.cleanupTypes.failedIncomingSyncTasks | quote }}
-  BLACK_LIST_SOURCES: {{ .Values.env.fs.blacklist_sources | quote }}
+  FS_BLACK_LIST_SOURCES_LOCATION: {{ .Values.env.fs.blacklist_sources_location | quote }}
 {{- end }}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -39,4 +39,5 @@ data:
   CLEANUP_TYPES_FAILED_INGESTION_TASKS: {{ .Values.env.cleanupTypes.failedIngestionTasks | quote }}
   CLEANUP_TYPES_SUCCESSFUL_INGESTION: {{ .Values.env.cleanupTypes.successfulIngestion | quote }}
   CLEANUP_TYPES_FAILED_INCOMING_SYNC_TASKS: {{ .Values.env.cleanupTypes.failedIncomingSyncTasks | quote }}
+  BLACK_LIST_SOURCES: {{ .Values.env.fs.blacklist_sources | quote }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -93,6 +93,8 @@ env:
   metrics:
     enabled: false
     url: http://localhost:55681/v1/metrics
+  fs:
+    blacklist_sources: "test_dir"
   s3:
     maxRetries: 3
     apiVersion: 2006-03-01

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -94,7 +94,7 @@ env:
     enabled: false
     url: http://localhost:55681/v1/metrics
   fs:
-    blacklist_sources: "test_dir"
+    blacklist_sources_location: "test_dir"
   s3:
     maxRetries: 3
     apiVersion: 2006-03-01

--- a/src/cleanupCommand/cleanupManager.ts
+++ b/src/cleanupCommand/cleanupManager.ts
@@ -32,8 +32,6 @@ export class CleanupManager {
     deleteDate.setDate(deleteDate.getDate() - FAILED_CLEANUP_DELAY);
 
     const notCleanedAndFailedNew = await this.jobManager.getFailedAndNotCleanedIngestionJobs(this.newIngestionJobType);
-    const notCleanedAndFailedUpdate = await this.jobManager.getFailedAndNotCleanedIngestionJobs(this.updateIngestionJobType);
-
     for (let i = 0; i < notCleanedAndFailedNew.length; i += this.discreteBatchSize) {
       const currentBatch = notCleanedAndFailedNew.slice(i, i + this.discreteBatchSize);
       const expiredBatch = this.filterExpiredFailedTasks(currentBatch, deleteDate);
@@ -47,6 +45,7 @@ export class CleanupManager {
       await this.jobManager.markAsCompletedAndRemoveFiles(completedDiscretes);
     }
 
+    const notCleanedAndFailedUpdate = await this.jobManager.getFailedAndNotCleanedIngestionJobs(this.updateIngestionJobType);
     for (let i = 0; i < notCleanedAndFailedUpdate.length; i += this.discreteBatchSize) {
       const currentBatch = notCleanedAndFailedUpdate.slice(i, i + this.discreteBatchSize);
       const expiredBatch = this.filterExpiredFailedTasks(currentBatch, deleteDate);


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |

* adding black list param to dismiss deletion of provided sources folders names
* fixing logic of update cleanup - do not remove tiles output on failure