### PR TITLE
chore: disable sources cleanup (MAPCO-3907)

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -80,6 +80,12 @@
       "__format": "number"
     }
   },
+  "disable_cleanup": {
+    "sources": {
+      "__name": "DISABLE_SOURCES_CLEANUP",
+      "__format": "boolean"
+    }
+  },
   "httpRetry": {
     "attempts": {
       "__name": "HTTP_RETRY_ATTEMPTS",

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -74,6 +74,12 @@
       "__format": "number"
     }
   },
+  "success_cleanup_delay_days": {
+    "ingestion": {
+      "__name": "SUCCESS_INGESTION_CLEANUP_DELAY_DAYS",
+      "__format": "number"
+    }
+  },
   "httpRetry": {
     "attempts": {
       "__name": "HTTP_RETRY_ATTEMPTS",

--- a/config/default.json
+++ b/config/default.json
@@ -47,6 +47,9 @@
   "success_cleanup_delay_days": {
     "ingestion": 0
   },
+  "disable_cleanup": {
+    "sources": false
+  },
   "httpRetry": {
     "attempts": 3,
     "delay": "exponential",

--- a/config/default.json
+++ b/config/default.json
@@ -44,6 +44,9 @@
     "ingestion": 14,
     "sync": 14
   },
+  "success_cleanup_delay_days": {
+    "ingestion": 0
+  },
   "httpRetry": {
     "attempts": 3,
     "delay": "exponential",

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -36,6 +36,7 @@ data:
   FAILED_INGESTION_CLEANUP_DELAY_DAYS: {{ .Values.env.failedCleanupDelayDays.ingestion | quote }}
   FAILED_SYNC_CLEANUP_DELAY_DAYS: {{ .Values.env.failedCleanupDelayDays.sync | quote }}
   SUCCESS_INGESTION_CLEANUP_DELAY_DAYS: {{ .Values.env.successCleanupDelayDays.ingestion | quote }}
+  DISABLE_SOURCES_CLEANUP: {{ .Values.env.disableCleanup.sources | quote }}
   HTTP_RETRY_ATTEMPTS: {{ .Values.env.httpRetry.attempts | quote }}
   HTTP_RETRY_DELAY: {{ .Values.env.httpRetry.delay | quote }}
   HTTP_RETRY_RESET_TIMEOUT: {{ .Values.env.httpRetry.shouldResetTimeout | quote }}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -35,6 +35,7 @@ data:
   BATCH_SIZE_TILES_DELETION: {{ .Values.env.batchSize.tilesDeletion | quote }}
   FAILED_INGESTION_CLEANUP_DELAY_DAYS: {{ .Values.env.failedCleanupDelayDays.ingestion | quote }}
   FAILED_SYNC_CLEANUP_DELAY_DAYS: {{ .Values.env.failedCleanupDelayDays.sync | quote }}
+  SUCCESS_INGESTION_CLEANUP_DELAY_DAYS: {{ .Values.env.successCleanupDelayDays.ingestion | quote }}
   HTTP_RETRY_ATTEMPTS: {{ .Values.env.httpRetry.attempts | quote }}
   HTTP_RETRY_DELAY: {{ .Values.env.httpRetry.delay | quote }}
   HTTP_RETRY_RESET_TIMEOUT: {{ .Values.env.httpRetry.shouldResetTimeout | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -128,6 +128,8 @@ env:
   failedCleanupDelayDays:
     ingestion: 14
     sync: 14
+  successCleanupDelayDays: 
+    ingestion: 14
   httpRetry:
     attempts: 3
     delay: exponential

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -130,6 +130,8 @@ env:
     sync: 14
   successCleanupDelayDays: 
     ingestion: 14
+  disableCleanup:
+    sources: false  
   httpRetry:
     attempts: 3
     delay: exponential

--- a/src/cleanupCommand/cleanupManager.ts
+++ b/src/cleanupCommand/cleanupManager.ts
@@ -99,10 +99,12 @@ export class CleanupManager {
         ignoredSources: ignoredSources.length ? ignoredSources.map((source) => source.parameters.originDirectory) : [],
       });
       const expiredBatch = this.filterExpiredFailedTasks(blackListFilteredBatch, this.successCleanupDelayDays);
-      const sourcesDirectories = this.getSourcesLocation(expiredBatch);
+
       if (!this.disableSourcesCleanup) {
+        const sourcesDirectories = this.getSourcesLocation(expiredBatch);
         await this.sourcesProvider.deleteDiscretes(sourcesDirectories);
       }
+
       await this.jobManager.markAsCompletedAndRemoveFiles(currentBatch);
       this.logger.info({
         msg: `Complete and mark jobs as 'Completed' with file directories remove`,

--- a/tests/integration/cleanupCommand/cleanupCommand.spec.ts
+++ b/tests/integration/cleanupCommand/cleanupCommand.spec.ts
@@ -19,6 +19,7 @@ import { mapproxyClientMock, deleteLayersMock } from '../../mocks/clients/mappro
 import { initConfig, configMock, setConfigValue } from '../../mocks/config';
 import { discreteArray, swapDiscreteArray } from '../../testData';
 import { CleanupCommandCliTrigger } from './helpers/CliTrigger';
+import { IDataLocation } from '../../../src/common/interfaces';
 
 describe('CleanupCommand', function () {
   let cli: CleanupCommandCliTrigger;
@@ -80,6 +81,7 @@ describe('CleanupCommand', function () {
       setConfigValue('batch_size.discreteLayers', 100);
       setConfigValue('failed_cleanup_delay_days.ingestion', 14);
       setConfigValue('failed_cleanup_delay_days.sync', 14);
+      setConfigValue('success_cleanup_delay_days.ingestion', 0);
       const failedAndNotCleaned = discreteArray.slice(0, 2);
       const successAndNotCleaned = discreteArray.slice(2, 4);
       const failedSyncAndNotCleaned = discreteArray.slice(4);
@@ -93,10 +95,7 @@ describe('CleanupCommand', function () {
       markAsCompletedMock.mockResolvedValue(undefined);
 
       await cli.cleanup();
-      const expectedFailedTilesLocations = [
-        { directory: failedAndNotCleaned[0].parameters.metadata.id, subDirectory: failedAndNotCleaned[0].parameters.metadata.displayPath },
-        { directory: failedAndNotCleaned[1].parameters.metadata.id, subDirectory: failedAndNotCleaned[1].parameters.metadata.displayPath },
-      ];
+      const expectedExpiredFailedTilesLocations: IDataLocation[] = [];
       const expectedSwappedTilesLocations = [
         { directory: swapDiscreteArray[0].parameters.metadata.id, subDirectory: swapDiscreteArray[0].parameters.cleanupData.previousRelativePath },
       ];
@@ -108,7 +107,7 @@ describe('CleanupCommand', function () {
         { directory: successAndNotCleaned[1].parameters.originDirectory },
       ];
       expect(tileProvider.deleteDiscretesMock).toHaveBeenCalledTimes(2);
-      expect(tileProvider.deleteDiscretesMock).toHaveBeenNthCalledWith(1, expectedFailedTilesLocations);
+      expect(tileProvider.deleteDiscretesMock).toHaveBeenNthCalledWith(1, expectedExpiredFailedTilesLocations);
       expect(tileProvider.deleteDiscretesMock).toHaveBeenNthCalledWith(2, expectedSwappedTilesLocations);
       expect(sourcesProvider.deleteDiscretesMock).toHaveBeenCalledTimes(3);
       expect(sourcesProvider.deleteDiscretesMock).toHaveBeenNthCalledWith(1, expectedSucceededTilesLocations);

--- a/tests/integration/cleanupCommand/cleanupCommand.spec.ts
+++ b/tests/integration/cleanupCommand/cleanupCommand.spec.ts
@@ -18,8 +18,8 @@ import {
 import { mapproxyClientMock, deleteLayersMock } from '../../mocks/clients/mapproxyClient';
 import { initConfig, configMock, setConfigValue } from '../../mocks/config';
 import { discreteArray, swapDiscreteArray } from '../../testData';
-import { CleanupCommandCliTrigger } from './helpers/CliTrigger';
 import { IDataLocation } from '../../../src/common/interfaces';
+import { CleanupCommandCliTrigger } from './helpers/CliTrigger';
 
 describe('CleanupCommand', function () {
   let cli: CleanupCommandCliTrigger;

--- a/tests/unit/cleanupCommand/cleanupManager.spec.ts
+++ b/tests/unit/cleanupCommand/cleanupManager.spec.ts
@@ -198,14 +198,12 @@ describe('CleanupManager', () => {
       const expiredJobs = [failedJobs[2]];
       const expectedSourceDirectories = [{ directory: expiredJobs[0].parameters.originDirectory }];
       const expectedTilesDirectories = [
-        { directory: failedJobs[0].parameters.metadata.id, subDirectory: failedJobs[0].parameters.metadata.displayPath },
-        { directory: failedJobs[1].parameters.metadata.id, subDirectory: failedJobs[1].parameters.metadata.displayPath },
         { directory: failedJobs[2].parameters.metadata.id, subDirectory: failedJobs[2].parameters.metadata.displayPath },
       ];
 
       expect(sourcesProviderMock.deleteDiscretesMock).toHaveBeenCalledWith(expectedSourceDirectories);
       expect(tileProviderMock.deleteDiscretesMock).toHaveBeenCalledWith(expectedTilesDirectories);
-      expect(deleteLayersMock).toHaveBeenCalledWith(failedJobs);
+      expect(deleteLayersMock).toHaveBeenCalledWith(expiredJobs);
       expect(markAsCompletedAndRemoveFilesMock).toHaveBeenCalledWith(expiredJobs);
     });
   });

--- a/tests/unit/cleanupCommand/cleanupManager.spec.ts
+++ b/tests/unit/cleanupCommand/cleanupManager.spec.ts
@@ -166,6 +166,7 @@ describe('CleanupManager', () => {
     initConfig();
     setConfigValue('batch_size.discreteLayers', 100);
     setConfigValue('fs.blacklist_sources_location', 'some_black_directory');
+    setConfigValue('disable_cleanup.sources', false);
     const logger = jsLogger({ enabled: false });
 
     manager = new CleanupManager(


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔`                                                                      |

Further  information:
adding option to disable sources cleanup.
