### PR TITLE
ci: changed shared-workflows tags to v2

### DIFF
--- a/.github/workflows/build_and_push.yaml
+++ b/.github/workflows/build_and_push.yaml
@@ -19,13 +19,13 @@ permissions:
 
 jobs:
   build_and_push_docker:
-      uses: MapColonies/shared-workflows/.github/workflows/build-and-push-docker.yaml@v3
+      uses: MapColonies/shared-workflows/.github/workflows/build-and-push-docker.yaml@v2
       secrets: inherit
       with:
         scope: raster
 
   build_and_push_helm:
-      uses: MapColonies/shared-workflows/.github/workflows/build-and-push-helm.yaml@v3
+      uses: MapColonies/shared-workflows/.github/workflows/build-and-push-helm.yaml@v2
       secrets: inherit
       with:
         scope: raster

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   pull_request:
-    uses: MapColonies/shared-workflows/.github/workflows/pull_request.yaml@v3
+    uses: MapColonies/shared-workflows/.github/workflows/pull_request.yaml@v2
     with: 
       enableOpenApiCheck: false
     secrets: inherit

--- a/.github/workflows/release-on-tag-push.yaml
+++ b/.github/workflows/release-on-tag-push.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release_on_tag_push:
-    uses: MapColonies/shared-workflows/.github/workflows/release-on-tag-push.yaml@v3
+    uses: MapColonies/shared-workflows/.github/workflows/release-on-tag-push.yaml@v2
     with: 
       enableOpenApiToPostman: false
     secrets: inherit


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->
Changed the shared-workflows tags back to v2 because v3 is about to be deleted
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |

