### PR TITLE
fix: removing max_old_space_size from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,5 @@ COPY --chown=node:node ./config ./config
 
 USER node
 EXPOSE 8080
-ENTRYPOINT ["dumb-init", "node", "--max_old_space_size=512", "./index.js"]
+ENTRYPOINT ["dumb-init", "node",  "./index.js"]
 CMD ["cleanup"]


### PR DESCRIPTION

| Question        | Answer |
| --------------- | ------ |
| Bug fix         | ✖      |
| New feature     | ✖      |
| Breaking change | ✖      |
| Deprecations    | ✖      |
| Documentation   | ✖      |
| Tests added     | ✖      |
| Chore           | ✔      |

